### PR TITLE
fixed url error in client.js

### DIFF
--- a/client.js
+++ b/client.js
@@ -10,8 +10,8 @@ internals.getOAuth = function (config) {
     };
 };
 
-internals.create = function (config, options) {
-    if (!options.host) {
+internals.create = function (config) {
+    if (!config.baseUrl) {
         throw new Error('options.host required (example: www.mymagentosite.com)');
     }
 


### PR DESCRIPTION
You pass a host as 'options' parameter which you don't use. Instead it does a control on config.baseUrl that is never passed as parameter